### PR TITLE
Remove inlined SVG using passthrough

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -10,9 +10,9 @@
 Incubating the Next Generation of +
 Graph Developer Tooling
 
-++++
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100px" height="100px" viewBox="0 0 100 100" preserveAspectRatio="none" style="enable-background:new 0 0 100 100;" xml:space="preserve" class="top"><polygon class="st0" points="100,100 0,100 100,0 "></polygon><line class="st1" x1="0" y1="100" x2="100" y2="0"></line></svg>
-++++
+//++++
+//<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100px" height="100px" viewBox="0 0 100 100" preserveAspectRatio="none" style="enable-background:new 0 0 100 100;" xml:space="preserve" class="top"><polygon class="st0" points="100,100 0,100 100,0 "></polygon><line class="st1" x1="0" y1="100" x2="100" y2="0"></line></svg>
+//++++
 
 [.buttons]
 * <<What is Neo4j Labs?, About>>
@@ -23,9 +23,9 @@ Graph Developer Tooling
 // <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100px" height="100px" viewBox="0 0 100 100" preserveAspectRatio="none" style="enable-background:new 0 0 100 100;" xml:space="preserve" class="bottom"><polygon class="st0" points="100,100 0,100 100,0 "></polygon><line class="st1" x1="0" y1="100" x2="100" y2="0"></line></svg>
 // ++++
 
-++++
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100px" height="100px" viewBox="0 0 100 100" preserveAspectRatio="none" style="enable-background:new 0 0 100 100;" xml:space="preserve" class="bottom to-leading"><polygon class="st0" points="100,100 0,100 100,0 "></polygon><line class="st1" x1="0" y1="100" x2="100" y2="0"></line></svg>
-++++
+//++++
+//<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100px" height="100px" viewBox="0 0 100 100" preserveAspectRatio="none" style="enable-background:new 0 0 100 100;" xml:space="preserve" class="bottom to-leading"><polygon class="st0" points="100,100 0,100 100,0 "></polygon><line class="st1" x1="0" y1="100" x2="100" y2="0"></line></svg>
+//++++
 
 
 


### PR DESCRIPTION
We should apply a custom style on the 'buttons' block in the UI to avoid mixing content and presentation.
Using passthrough with HTML also tighly coupled the document to a single output.