### PR TITLE
Update apoc links

### DIFF
--- a/modules/apoc/nav.adoc
+++ b/modules/apoc/nav.adoc
@@ -4,8 +4,5 @@
 // *** xref:tutorial.adoc[Getting Started]
 // *** xref:how-to-guide.adoc[How To Guide]
 *** Documentation
-**** link:/labs/apoc/4.3[4.3 (Current)]
-**** link:/labs/apoc/4.2[4.2]
-**** link:/labs/apoc/4.1[4.1]
-**** link:/labs/apoc/4.0[4.0]
-**** link:https://neo4j.com/docs/labs/apoc/3.5/[3.5^]
+**** link:/labs/apoc/4.4[4.4]
+**** link:/labs/apoc/4.3[4.3]

--- a/modules/apoc/pages/index.adoc
+++ b/modules/apoc/pages/index.adoc
@@ -1,5 +1,5 @@
 = Awesome Procedures On Cypher (APOC)
-:docs: https://neo4j.com/labs/apoc/4.1
+:docs: https://neo4j.com/labs/apoc/4.4
 :slug: apoc
 :author: Michael Hunger
 :category: labs
@@ -24,7 +24,7 @@ You can learn more in the https://neo4j.com/developer/neo4j-apoc/[APOC Developer
 
 [cols="1,4"]
 |===
-| icon:user[] Authors | Michael Hunger, lots of internal and external contributors, especially the team from http://larus-ba.it/neo4j/[Larus BA, Italy^] lead by Andrea Santurbano
+| icon:user[] Authors | Michael Hunger, lots of internal and external contributors, especially the team from http://larus-ba.it/[Larus BA, Italy^] lead by Andrea Santurbano
 | icon:gift[] Releases | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases
 | icon:github[] Source | https://github.com/neo4j-contrib/neo4j-apoc-procedures
 | icon:book[] Developer Guide | https://neo4j.com/developer/neo4j-apoc/

--- a/modules/apoc/pages/index.adoc
+++ b/modules/apoc/pages/index.adoc
@@ -4,7 +4,7 @@
 :author: Michael Hunger
 :category: labs
 :tags: apoc, procedures, functions, utilities, extensions, libraries
-:neo4j-versions: 3.5, 4.0
+:neo4j-versions: 3.5, 4.0, 4.1, 4.2, 4.3, 4.4, Aura
 :page-product: apoc
 
 
@@ -24,7 +24,7 @@ You can learn more in the https://neo4j.com/developer/neo4j-apoc/[APOC Developer
 
 [cols="1,4"]
 |===
-| icon:user[] Authors | Michael Hunger, lots of internal and external contributors, especially the team from http://larus-ba.it/[Larus BA, Italy^] lead by Andrea Santurbano
+| icon:user[] Authors | Michael Hunger, lots of internal and external contributors, especially the team from http://larus-ba.it/neo4j/[Larus BA, Italy^] lead by Andrea Santurbano
 | icon:gift[] Releases | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases
 | icon:github[] Source | https://github.com/neo4j-contrib/neo4j-apoc-procedures
 | icon:book[] Developer Guide | https://neo4j.com/developer/neo4j-apoc/

--- a/modules/neosemantics/pages/how-to-guide.adoc
+++ b/modules/neosemantics/pages/how-to-guide.adoc
@@ -549,4 +549,4 @@ If you have experienced any issues during this tutorial you may find the solutio
 
 [glossary]
 [[NEO4J_BROWSER]]Neo4j Browser:: link:https://neo4j.com/developer/neo4j-browser/[Neo4j Browser^] is a User Interface for  querying, visualization, and data interaction.  If your database is running, it can usually be accessed over HTTP on port `:7474` or `:7473` over HTTPS, eg. http://localhost:7474.
-[[APOC]]APOC:: xref:apoc[APOC] is a library of procedures and functions that make your life as a Neo4j user easier.
+[[APOC]]APOC:: xref:apoc:index.adoc[APOC] is a library of procedures and functions that make your life as a Neo4j user easier.

--- a/modules/neosemantics/pages/installation.adoc
+++ b/modules/neosemantics/pages/installation.adoc
@@ -103,5 +103,5 @@ The previous command assumes you're running neo4j on your local machine, replace
 [[NEO4J_HOME]]$NEO4J_HOME:: The directory in which you have installed Neo4j.  This will contain a `bin/` folder which holds the `neo4j` executable, plus conf, data and plugins.
 +
 For more information, see the link:/ops-manual[Operations Manual^]
-[[APOC]]APOC:: xref:apoc[APOC] is a library of procedures and functions that make your life as a Neo4j user easier.
+[[APOC]]APOC:: xref:apoc:index.adoc[APOC] is a library of procedures and functions that make your life as a Neo4j user easier.
 [[CausalCluster]]Causal Cluster:: A highly available cluster of Neo4j servers


### PR DESCRIPTION
Update apoc links

Related trello card: https://trello.com/c/oAXw0zO9/1017-references-in-main-apoc-documentation-page-point-to-41