### PR TITLE
Remove Kafka module from labs

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -13,7 +13,6 @@ nav:
 - modules/liquibase/nav.adoc
 - modules/neo4j-helm/nav.adoc
 - modules/neosemantics/nav.adoc
-- modules/kafka/nav.adoc
 - modules/neodash/nav.adoc
 
 asciidoc:


### PR DESCRIPTION
Refers to https://github.com/neo4j-documentation/docs-refresh/pull/85, where Kafka docs are redirected from /labs to /docs.