### PR TITLE
Update llamaindex.adoc to remove langchain reference

### DIFF
--- a/modules/genai-ecosystem/pages/llamaindex.adoc
+++ b/modules/genai-ecosystem/pages/llamaindex.adoc
@@ -32,7 +32,7 @@ The Neo4j integration covers both the vector store as well as query generation f
 
 The Neo4j Vector integration supports a number of operations
 
-* create vector from langchain documents
+* create vector from LlamaIndex documents
 * query vector
 * query vector with additional graph retrieval Cypher query
 * construct vector instance from existing graph data


### PR DESCRIPTION
Browsing the docs it looks like there might have been a copy/paste and references langchain for LlamaIndex. 