### PR TITLE
Switched banner and page title in NeoDash page

### DIFF
--- a/modules/neodash/pages/index.adoc
+++ b/modules/neodash/pages/index.adoc
@@ -1,9 +1,4 @@
-[NOTE]
-====
-This documentation pertains to the unsupported version of NeoDash, as part of Neo4j Labs.
-For users of the supported NeoDash offering, refer to https://neo4j.com/docs/neodash-commercial/[NeoDash commercial].
 
-====
 
 = NeoDash - Dashboard Builder for Neo4j
 :imagesdir: https://s3.amazonaws.com/dev.assets.neo4j.com/wp-content/uploads
@@ -22,6 +17,12 @@ For users of the supported NeoDash offering, refer to https://neo4j.com/docs/neo
 :page-ad-underline: Start Here
 :page-ad-link: https://neo4j.typeform.com/to/E6yOZ2Py?utm_source=GA&utm_medium=blurb&utm_campaign=survey
 
+[NOTE]
+====
+This documentation pertains to the unsupported version of NeoDash, as part of Neo4j Labs.
+For users of the supported NeoDash offering, refer to https://neo4j.com/docs/neodash-commercial/[NeoDash commercial].
+
+====
 
 image::neodash.png[width=800]
 


### PR DESCRIPTION
Having the banner above the title was causing the page title in the header to be 'untitled':
![image](https://github.com/user-attachments/assets/423ee86e-3e83-4966-a916-fe31392c4b82)

This PR fixes that issue.