### PR TITLE
 Add Neo4j Agent Memory documentation as external content source

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -41,7 +41,11 @@ Most integrations use a combination of vector and graph search to improve qualit
 === https://neo4j.com/developer/genai-ecosystem/model-context-protocol-mcp/[MCP Servers]
 
 The Model Context Protocol (MCP) allows LLMs and Agents to use APIs, databases and many other capabilities easily into their architecture via active function calling.
-The https://neo4j.com/developer/genai-ecosystem/model-context-protocol-mcp/[Neo4j Labs MCP Servers] cover a range of functionality, from executing Cypher or Graph Algorithms, to modeling graphs or managing Aura infrastructure. 
+The https://neo4j.com/developer/genai-ecosystem/model-context-protocol-mcp/[Neo4j Labs MCP Servers] cover a range of functionality, from executing Cypher or Graph Algorithms, to modeling graphs or managing Aura infrastructure.
+
+=== xref:agent-memory::index.adoc[Neo4j Agent Memory]
+
+xref:agent-memory::index.adoc[Neo4j Agent Memory] is a graph-based memory system for AI agents. It provides three types of memory - short-term (conversation context), long-term (persistent knowledge via entity extraction), and reasoning (decision traces) - all backed by Neo4j's graph database for rich relationship modeling and efficient retrieval. The library integrates with popular frameworks including LangChain, LlamaIndex, PydanticAI, CrewAI, and OpenAI Agents.
 
 === xref:genai-ecosystem:llm-graph-builder.adoc[LLM Knowledge Graph Builder]
 
@@ -72,7 +76,7 @@ Liquibase is an open source project for tracking, managing and applying database
 
 === xref:neo4j-aura-terraform-provider:index.adoc[Neo4j Aura Terraform Provider]
 
-Neo4j Aura Terraform Provider is Neo4j Labs tool that allows infrastructure-as-code management of Neo4j AuraDB resources, primarily focusing on the lifecycle of AuraDB through declarative Terraform configurations.  
+Neo4j Aura Terraform Provider is Neo4j Labs tool that allows infrastructure-as-code management of Neo4j AuraDB resources, primarily focusing on the lifecycle of AuraDB through declarative Terraform configurations.
 
 
 === xref:neo4j-migrations:index.adoc[Neo4j-Migrations]

--- a/preview.yml
+++ b/preview.yml
@@ -4,8 +4,12 @@ site:
 
 content:
   sources:
-  - url: ./
-    branches: publish
+    - url: ./
+      branches: publish
+    # Neo4j Agent Memory - external content source
+    - url: https://github.com/neo4j-labs/agent-memory.git
+      branches: main
+      start_path: docs
 
 ui:
   bundle:
@@ -17,8 +21,8 @@ urls:
 
 asciidoc:
   extensions:
-  - "@neo4j-documentation/remote-include"
-  - "@neo4j-documentation/macros"
+    - "@neo4j-documentation/remote-include"
+    - "@neo4j-documentation/macros"
   attributes:
     page-theme: labs
     page-disabletracking: true


### PR DESCRIPTION
Adds Neo4j Agent Memory to the Labs Pages documentation site. Neo4j Agent Memory is a graph-based memory system for AI agents providing short-term, long-term, and reasoning memory backed by Neo4j.

### Changes

- **preview.yml**: Added `neo4j-labs/agent-memory` as an external content source
- **modules/ROOT/pages/index.adoc**: Added Agent Memory to the Current Projects listing
- **.github/workflows/main.yml**: Added `repository_dispatch` trigger to rebuild when agent-memory docs are updated

### How It Works

The documentation content lives in the `neo4j-labs/agent-memory` repository under `docs/`. Antora fetches this content during build via the external content source configuration:

```yaml
- url: https://github.com/neo4j-labs/agent-memory.git
  branches: main
  start_path: docs
```

When documentation changes are pushed to agent-memory, a GitHub Actions workflow triggers a rebuild of labs-pages via repository dispatch.

### URLs

Once deployed, the documentation will be available at:
- `https://neo4j.com/labs/agent-memory/` - Main landing page
- `https://neo4j.com/labs/agent-memory/tutorials/` - Tutorials
- `https://neo4j.com/labs/agent-memory/how-to/` - How-to guides
- `https://neo4j.com/labs/agent-memory/reference/` - API reference
- `https://neo4j.com/labs/agent-memory/explanation/` - Concepts

### Dependencies

Requires [the corresponding PR in `neo4j-labs/agent-memory` to be merged](https://github.com/neo4j-labs/agent-memory/pull/38) first to restructure the docs for Antora compatibility.

### Setup Required

A GitHub secret `LABS_PAGES_TOKEN` needs to be configured in the agent-memory repository with a PAT that has permissions to trigger repository dispatch events on `neo4j-contrib/labs-pages`.